### PR TITLE
Comms: simplify timeout handling

### DIFF
--- a/src/UdpMulticastDriver.cpp
+++ b/src/UdpMulticastDriver.cpp
@@ -8,11 +8,11 @@
 #include <bci/abs/UdpMulticastDriver.h>
 
 #include <array>
-#include <atomic>
 #include <boost/asio.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/write.hpp>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -20,7 +20,6 @@
 
 #include "Util.h"
 
-using boost::asio::deadline_timer;
 using boost::asio::ip::udp;
 
 namespace bci::abs::drivers {
@@ -49,12 +48,10 @@ struct UdpMcastDriver::Impl {
 
   boost::asio::io_service io_service_;
   boost::asio::ip::udp::socket socket_;
-  boost::asio::deadline_timer deadline_;
   boost::asio::ip::udp::endpoint endpoint_;
   std::array<std::uint8_t, kBufLen> buf_;
-  std::atomic<bool> timeout_;
 
-  void CheckDeadline();
+  bool Run(unsigned int timeout_ms);
 };
 
 UdpMcastDriver::UdpMcastDriver() : impl_(std::make_shared<Impl>()) {}
@@ -84,13 +81,8 @@ Result<UdpMcastDriver::AddressedResponse> UdpMcastDriver::ReadLineFrom(
 UdpMcastDriver::Impl::Impl()
     : io_service_(),
       socket_(io_service_),
-      deadline_(io_service_),
       endpoint_(),
-      buf_{},
-      timeout_{} {
-  deadline_.expires_at(boost::posix_time::pos_infin);
-  CheckDeadline();
-}
+      buf_{} { }
 
 UdpMcastDriver::Impl::~Impl() { Close(); }
 
@@ -155,19 +147,12 @@ ErrorCode UdpMcastDriver::Impl::Write(std::string_view data,
     return ErrorCode::kNotConnected;
   }
 
-  timeout_ = false;
-  deadline_.expires_from_now(boost::posix_time::milliseconds(timeout_ms));
-
-  boost::system::error_code ec = boost::asio::error::would_block;
+  boost::system::error_code ec;
 
   const auto write_handler = [&](auto&& e, auto&&) { ec = e; };
   socket_.async_send_to(boost::asio::buffer(data), endpoint_, write_handler);
 
-  do {
-    io_service_.run_one();
-  } while (ec == boost::asio::error::would_block);
-
-  if (timeout_) {
+  if (!Run(timeout_ms)) {
     return ErrorCode::kSendTimedOut;
   }
 
@@ -183,10 +168,7 @@ Result<std::string> UdpMcastDriver::Impl::ReadLine(unsigned int timeout_ms) {
     return Err(ErrorCode::kNotConnected);
   }
 
-  timeout_ = false;
-  deadline_.expires_from_now(boost::posix_time::milliseconds(timeout_ms));
-
-  boost::system::error_code ec = boost::asio::error::would_block;
+  boost::system::error_code ec;
 
   std::size_t read_len{};
 
@@ -196,11 +178,7 @@ Result<std::string> UdpMcastDriver::Impl::ReadLine(unsigned int timeout_ms) {
   };
   socket_.async_receive(boost::asio::buffer(buf_), read_handler);
 
-  do {
-    io_service_.run_one();
-  } while (ec == boost::asio::error::would_block);
-
-  if (timeout_) {
+  if (!Run(timeout_ms)) {
     return Err(ErrorCode::kReadTimedOut);
   }
 
@@ -219,10 +197,7 @@ Result<UdpMcastDriver::AddressedResponse> UdpMcastDriver::Impl::ReadLineFrom(
     return Err(ErrorCode::kNotConnected);
   }
 
-  timeout_ = false;
-  deadline_.expires_from_now(boost::posix_time::milliseconds(timeout_ms));
-
-  boost::system::error_code ec = boost::asio::error::would_block;
+  boost::system::error_code ec;
 
   std::size_t read_len{};
   udp::endpoint source;
@@ -233,11 +208,7 @@ Result<UdpMcastDriver::AddressedResponse> UdpMcastDriver::Impl::ReadLineFrom(
   };
   socket_.async_receive_from(boost::asio::buffer(buf_), source, read_handler);
 
-  do {
-    io_service_.run_one();
-  } while (ec == boost::asio::error::would_block);
-
-  if (timeout_) {
+  if (!Run(timeout_ms)) {
     return Err(ErrorCode::kReadTimedOut);
   }
 
@@ -250,14 +221,19 @@ Result<UdpMcastDriver::AddressedResponse> UdpMcastDriver::Impl::ReadLineFrom(
   return AddressedResponse{source.address().to_string(), std::move(line)};
 }
 
-void UdpMcastDriver::Impl::CheckDeadline() {
-  if (deadline_.expires_at() <= deadline_timer::traits_type::now()) {
-    timeout_ = true;
-    socket_.cancel();
-    deadline_.expires_at(boost::posix_time::pos_infin);
+bool UdpMcastDriver::Impl::Run(unsigned int timeout_ms) {
+  io_service_.restart();
+
+  io_service_.run_for(std::chrono::milliseconds(timeout_ms));
+
+  if (!io_service_.stopped()) {
+    boost::system::error_code ignored;
+    socket_.cancel(ignored);
+    io_service_.run();
+    return false;
   }
 
-  deadline_.async_wait([&](auto&&) { this->CheckDeadline(); });
+  return true;
 }
 
 }  // namespace bci::abs::drivers


### PR DESCRIPTION
The previous solution for handling timeouts was more complex than it needed to be, relying on a `boost::asio::deadline_timer` and `async_wait()`. This can be simplified quite a bit to just calling `run_for()` on the IO context, which will also detect whether the operation timed out (i.e., didn't complete before the time limit was reached).