### PR TITLE
Update Boost to 1.88.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,13 @@ set(Boost_USE_STATIC_LIBS ON)
 set(BOOST_INCLUDE_LIBRARIES system asio)
 set(BOOST_ENABLE_CMAKE ON)
 # use CONFIG to avoid CMP0167 warnings
-find_package(Boost 1.81.0 CONFIG COMPONENTS system QUIET)
+find_package(Boost 1.88.0 CONFIG COMPONENTS system QUIET)
 if (NOT Boost_FOUND)
   set(SAVED_BUILD_SHARED ${BUILD_SHARED_LIBS})
   set(BUILD_SHARED_LIBS OFF)
   FetchContent_Declare(Boost
-    URL https://github.com/boostorg/boost/releases/download/boost-1.81.0/boost-1.81.0.tar.gz
-    URL_HASH "SHA1=f71f661f893f39b7b82d66c54980349716f874a2"
+    URL https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-cmake.tar.gz
+    URL_HASH "SHA1=7667d5edc4e753965db02595c912f78ad64725fe"
   )
   FetchContent_GetProperties(Boost)
   if(NOT Boost_POPULATED)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ them if your installed versions are compatible. Otherwise, it will automatically
 fetch and build them as part of the build. The build dependencies are:
 
 - fmt v10.2.1
-- Boost v1.81.0
+- Boost v1.88.0
 - FastFloat v6.1.1
 
 These are all linked statically, regardless of the build configuration.


### PR DESCRIPTION
This fixes CMake 3.5 deprecation warnings (errors as of CMake 4.0). Minor updates to the drivers to match, as they used the Asio class `io_service` which is officially gone (replaced with the proper `io_context`).