### PR TITLE
Add library version function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,10 @@ set_target_properties(absscpi PROPERTIES
 
 target_compile_features(absscpi PUBLIC cxx_std_20)
 
+target_compile_definitions(absscpi PRIVATE
+  "ABSSCPI_VERSION=((${PROJECT_VERSION_MAJOR}* 10000)+(${PROJECT_VERSION_MINOR}*100)+(${PROJECT_VERSION_PATCH}))"
+)
+
 if(MSVC)
   target_compile_options(absscpi PRIVATE /W3)
 else()

--- a/include/bci/abs/CInterface.h
+++ b/include/bci/abs/CInterface.h
@@ -190,6 +190,18 @@ typedef struct AbsSerialDiscoveryResult {
 /** @} */
 
 /**
+ * @brief Get the version of the SCPI library as an unsigned base 10 integer.
+ * For example, version 1.2.3 would return 10203.
+ *
+ * This is intended to be used to check for the existence of certain
+ * functionality based on library version, particularly in wrappers (such as
+ * Python).
+ *
+ * @return The library version.
+ */
+unsigned int AbsScpiClient_Version();
+
+/**
  * @brief Get an error message to describe an error code returned by the driver.
  *
  * @return Null-terminated error message string.

--- a/include/bci/abs/ScpiClient.h
+++ b/include/bci/abs/ScpiClient.h
@@ -53,6 +53,14 @@ namespace bci::abs {
  */
 class ScpiClient {
  public:
+  /**
+   * @brief Get the library version as a decimal integer. For example, version
+   * 1.3.2 would return 10302.
+   *
+   * @return Library version.
+   */
+  static unsigned int Version() noexcept;
+
   /// Default CTOR.
   ScpiClient() noexcept;
 

--- a/src/CInterface.cpp
+++ b/src/CInterface.cpp
@@ -87,6 +87,10 @@ inline constexpr std::string_view CharsView(const char (&str)[kLen]) {
   return std::string_view(str, ::strnlen(str, kLen));
 }
 
+unsigned int AbsScpiClient_Version() {
+  return ABSSCPI_VERSION;
+}
+
 const char* AbsScpiClient_ErrorMessage(int error) {
   return bci::abs::ErrorMessage(static_cast<bci::abs::ErrorCode>(error));
 }

--- a/src/ScpiClient.cpp
+++ b/src/ScpiClient.cpp
@@ -22,6 +22,10 @@ static constexpr unsigned int kWriteTimeoutMs = 10;
 using util::Err;
 using ec = ErrorCode;
 
+unsigned int ScpiClient::Version() noexcept {
+  return ABSSCPI_VERSION;
+}
+
 ScpiClient::ScpiClient() noexcept : ScpiClient(nullptr) {}
 
 ScpiClient::ScpiClient(std::shared_ptr<drivers::CommDriver> driver) noexcept


### PR DESCRIPTION
This is intended to allow wrappers around the library to determine dynamically which features are supported. Unfortunately, since this was not available from the start, it does mean that they will have to check for the existence of this function to begin with.